### PR TITLE
Small correction

### DIFF
--- a/slides/03-riot-basics/riot-basics.md
+++ b/slides/03-riot-basics/riot-basics.md
@@ -311,7 +311,7 @@ void *thread_handler(void *arg)
 }
 ```
 
-- When using synchronous messaging (typically the case with ISR), always
+- When using asynchronous messaging (typically the case with ISR), always
   initialize a thread message queue in the thread handler:
 
 ```c


### PR DESCRIPTION
Hi !

I was following your tutorial at INRIA last week, and I found out what seems to be a writing miskake.

It was said that synchronous IPC needs message queue

> When using synchronous messaging (typically the case with ISR),
> initialize a thread message queue in the thread handler

But RIOT OS api says 

>Synchronous IPC is the default mode i.e. is active when the receiving thread has no message queue initialized

https://riot-os.org/api/group__core__msg.html

Have a good day !

Anthony
