### PR TITLE
riot-summit: 05-lorawan-with-RIOT: adapt slides

### DIFF
--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -432,29 +432,6 @@ _TIP_: see `~/RIOT/tests/pkg_cayenne-lpp` sample application
 
 ---
 
-## Final application: adding low power
-
-- **Exercise:** `~/riot-course-exercises/riot-lorawan/pm`
-
-- **Objective:**
-
-  - Start from application `~/riot-course-exercises/riot-lorawan/sensor`
-
-  - Modify the sender thread so that it triggers a send only after a message is
-    received
-
-  - After a LoRaWAN send, configure an RTC alarm 20s later
-
-  - In the RTC alarm callback, send a message to the sender thread
-
-  - Test the application
-
-  - Include `pm_layered.h` and use `pm_set(1)` to put the CPU in STOP mode
-    after the RTC alarm is set
-    (check the differences with pm_set(0))
-
----
-
 ## The TTN MQTT API
 
 - MQTT protocol uses a publish/subscribe approach

--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -361,7 +361,7 @@ Tx done
 
 ---
 
-## TTN with RIOT: practice (2)
+## Sending sensor data to TTN: practice
 
 - **Exercise:** `~/riot-course-exercises/riot-lorawan/sensor`
 

--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -450,26 +450,11 @@ https://www.eclipse.org/paho/
 
 ---
 
-## Using the MQTT API
+## The TTN MQTT API
 
 .center[
     <img src="images/overview_application.png" alt="" style="width: 350px;"/><br/>
 ]
-
-- Listening to uplink messages (device to network):
-
-```sh
-$ mosquitto_sub -h eu.thethings.network -p 1883 -u <username> -P <password>
--t '+/devices/+/up'
-```
-
-- Sending a downlink message (network to device):
-
-```sh
-$ mosquitto_pub -h eu.thethings.network -p 1883 -u <username> -P <password>
--t '<application id>/devices/<device id>/down'
--m '{"port":2, "payload_raw":"dGVzdA=="}'
-```
 
 ---
 

--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -401,7 +401,7 @@ https://mydevices.com/cayenne/docs/lora/#lora-the-things-network
 
 ---
 
-## Integration with Cayenne: pratice
+## Integration with Cayenne: practice
 
 - **Exercise:** `~/riot-course-exercises/riot-lorawan/lpp`
 

--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -401,7 +401,7 @@ https://mydevices.com/cayenne/docs/lora/#lora-the-things-network
 
 ---
 
-## Integration with Cayenne: practice
+## Integration with Cayenne LPP: practice
 
 - **Exercise:** `~/riot-course-exercises/riot-lorawan/lpp`
 
@@ -433,13 +433,13 @@ https://www.eclipse.org/paho/
 
 ---
 
-## TTN with RIOT: practice (1)
+## TTN with RIOT: practice (3)
 
 - **Exercise:** `~/riot-course-exercises/riot-lorawan/downlink`
 
 ---
 
-## Final application: adding low power
+## Final application: add low power
 
 - **Exercise:** `~/riot-course-exercises/riot-lorawan/pm`
 

--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -361,18 +361,6 @@ Tx done
 
 ---
 
-## Test TTN with RIOT: practice (3)
-
-- **Exercise:** `~/riot-course-exercises/riot-lorawan/thread`
-
-- **Objective:** Adapt your previous application as follows:
-
-  1. Join the network from the main application
-
-  2. Start a sender thread that sends messages every 20s
-
----
-
 ## The TTN MQTT API
 
 - MQTT protocol uses a publish/subscribe approach

--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -361,47 +361,6 @@ Tx done
 
 ---
 
-## The TTN MQTT API
-
-- MQTT protocol uses a publish/subscribe approach
-.center[
-    <img src="images/pub-sub-model.png" alt="" style="width: 350px;"/><br/>
-]
-
-- TTN MQTT API documentation<br>
-https://www.thethingsnetwork.org/docs/applications/mqtt/
-
-- Reference implementation provided by the Eclipse Mosquitto project<br>
-https://mosquitto.org/
-
-- Eclipse also provides a python library: _paho_<br>
-https://www.eclipse.org/paho/
-
----
-
-## Using the MQTT API
-
-.center[
-    <img src="images/overview_application.png" alt="" style="width: 350px;"/><br/>
-]
-
-- Listening to uplink messages (device to network):
-
-```sh
-$ mosquitto_sub -h eu.thethings.network -p 1883 -u <username> -P <password>
--t '+/devices/+/up'
-```
-
-- Sending a downlink message (network to device):
-
-```sh
-$ mosquitto_pub -h eu.thethings.network -p 1883 -u <username> -P <password>
--t '<application id>/devices/<device id>/down'
--m '{"port":2, "payload_raw":"dGVzdA=="}'
-```
-
----
-
 ## TTN with RIOT: practice (2)
 
 - **Exercise:** `~/riot-course-exercises/riot-lorawan/sensor`
@@ -493,6 +452,47 @@ _TIP_: see `~/RIOT/tests/pkg_cayenne-lpp` sample application
   - Include `pm_layered.h` and use `pm_set(1)` to put the CPU in STOP mode
     after the RTC alarm is set
     (check the differences with pm_set(0))
+
+---
+
+## The TTN MQTT API
+
+- MQTT protocol uses a publish/subscribe approach
+.center[
+    <img src="images/pub-sub-model.png" alt="" style="width: 350px;"/><br/>
+]
+
+- TTN MQTT API documentation<br>
+https://www.thethingsnetwork.org/docs/applications/mqtt/
+
+- Reference implementation provided by the Eclipse Mosquitto project<br>
+https://mosquitto.org/
+
+- Eclipse also provides a python library: _paho_<br>
+https://www.eclipse.org/paho/
+
+---
+
+## Using the MQTT API
+
+.center[
+    <img src="images/overview_application.png" alt="" style="width: 350px;"/><br/>
+]
+
+- Listening to uplink messages (device to network):
+
+```sh
+$ mosquitto_sub -h eu.thethings.network -p 1883 -u <username> -P <password>
+-t '+/devices/+/up'
+```
+
+- Sending a downlink message (network to device):
+
+```sh
+$ mosquitto_pub -h eu.thethings.network -p 1883 -u <username> -P <password>
+-t '<application id>/devices/<device id>/down'
+-m '{"port":2, "payload_raw":"dGVzdA=="}'
+```
 
 ---
 

--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -402,27 +402,6 @@ $ mosquitto_pub -h eu.thethings.network -p 1883 -u <username> -P <password>
 
 ---
 
-## TTN with RIOT: practice (1)
-
-- **Exercise:** `~/riot-course-exercises/riot-lorawan/downlink`
-
-- **Objective:**
-
-  - Use the `mosquitto_sub` command to receive the messages sent by the device
-
-  - Modify the `downlink` application to make LED1 blink when a message is
-    received
-
-  - Use `mosquitto_pub` to send downlink messages to the device and verify
-    that the firmware behaves as expected
-
-_TIP_: base64 payload can be decoded with the command
-```sh
-$ base64 -d <<< dGVzdA==
-```
-
----
-
 ## TTN with RIOT: practice (2)
 
 - **Exercise:** `~/riot-course-exercises/riot-lorawan/sensor`

--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -473,6 +473,18 @@ $ mosquitto_pub -h eu.thethings.network -p 1883 -u <username> -P <password>
 
 ---
 
+## TTN with RIOT: practice (1)
+
+- **Exercise:** `~/riot-course-exercises/riot-lorawan/downlink`
+
+---
+
+## Final application: adding low power
+
+- **Exercise:** `~/riot-course-exercises/riot-lorawan/pm`
+
+---
+
 class: center, middle
 
 # The End

--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -350,28 +350,11 @@ Tx done
 
 - **Exercise:** `~/riot-course-exercises/riot-lorawan/simple`
 
-- **Objective:**
-
-  - Follow the [RIOT Semtech Loramac package online documentation](http://doc.riot-os.org/group__pkg__semtech-loramac.html)
-    and write an application that sends "This is
-    RIOT!" every 20 seconds
-
-  - Configure the application for OTAA activation (use your Device EUI,
-    application EUI and application key)
-
 ---
 
 ## Sending sensor data to TTN: practice
 
 - **Exercise:** `~/riot-course-exercises/riot-lorawan/sensor`
-
-- **Objective:**
-
-  - Modify the application in `~/riot-course-exercises/riot-lorawan/thread` to
-    make it read and send every 20s the HTS221 sensor values. The format of the
-    message will be `T: XX.X°C, H: XX.X%`
-
-_TIP_: Reuse parts of the code from `~/riot-basics/drivers` application
 
 ---
 
@@ -421,14 +404,6 @@ https://mydevices.com/cayenne/docs/lora/#lora-the-things-network
 ## Integration with Cayenne: pratice
 
 - **Exercise:** `~/riot-course-exercises/riot-lorawan/lpp`
-
-- **Objective:**
-
-  - Modify the application in `~/riot-course-exercises/riot-lorawan/sensor` to
-    make it compatible with the Cayenne LPP format: use the `cayenne-lpp`
-    package.
-
-_TIP_: see `~/RIOT/tests/pkg_cayenne-lpp` sample application
 
 ---
 


### PR DESCRIPTION
This PR adapts the 05-lorawan-with-RIOT with the following changes:

EDIT:
1. Remove `thread` exercises
2. Update titles of exercises
3. Move the MQTT part to the end
4. Fix a typo.

So, the order of exercises would be:

1. Test with pkg_semtech_loramac
2. Test with `simple`
3. Send sensor data to TTN
4. Cayenne LPP

And for the braves:
5. MQTT
6. Downlink
7. Adding low power

PS: I'm adding a `riot-summit` prefix so it's easier to cherry pick later if there's something :P