### PR TITLE
05-lorawan-with-riot: fix lora modulation specs

### DIFF
--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -57,8 +57,8 @@ class: center, middle
         <br/><br/>
             <ul>
                 <li>increases the range (until several kilometers)</li>
-                <li>decreases the bandwidth</li>
                 <li>increases the time on air</li>
+                <li>increases energy consumption</li>
             </ul>
         </li>
     </ul>

--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -44,7 +44,7 @@ class: center, middle
   <td><ul>
   <li>Long range radio technology<br/><br/></li>
   <li>Spread Spectrum modulation: <br/><br/>&#x21d2; "Chirp Spread Spectrum"<br/><br/></li>
-  <li>Very robust to noise</li>
+  <li>Very robust to noise, multipath and Doppler effect</li>
   </ul></td>
   <td>.center[
       <img src="images/lora-chirp.jpg" alt="" style="width: 200px;"/><br/>


### PR DESCRIPTION
This PR fixes the following:

1. Adds `multipath and Doppler effects` to the LoRa modulation specs, which adds notions for using LoRa in moving objects.
2. Replaces the `decreases the bandwidth` with `increases energy consumption`. Bandwidth and Spreading Factor are independent in the LoRa modulation. And also, the longer it takes to send a packet the more energy consumed.