### PR TITLE
05-lorawan-with-riot: add time on air calculation

### DIFF
--- a/slides/05-lorawan-with-riot/lorawan-with-riot.md
+++ b/slides/05-lorawan-with-riot/lorawan-with-riot.md
@@ -107,6 +107,17 @@ class: center, middle
 
 ---
 
+## Time On Air
+
+Dependent on several factors: payload, bandwidth, spreading factor, etc.
+
+Calculating the TOA:
+- [LoRa Airtime Calculator spreadsheet](https://docs.google.com/spreadsheets/d/1voGAtQAjC1qBmaVuP1ApNKs1ekgUjavHuVQIXyYSvNc/edit#gid=0)
+- [lorawan_toa package](https://github.com/tanupoo/lorawan_toa)
+- [Equations from LoRa designer's guide](https://www.semtech.com/uploads/documents/LoraDesignGuide_STD.pdf)
+
+---
+
 ## Class A & C devices
 
 <table style="width:100%">


### PR DESCRIPTION
This PR adds a slide for pointing out how to estimate the Time On Air, important for respecting the LoRaWAN regulation.