### PR TITLE
05-lorawan-with-riot: fix typo

### DIFF
--- a/slides/tutorial-summit-2018/summit2018-tutorial.md
+++ b/slides/tutorial-summit-2018/summit2018-tutorial.md
@@ -100,7 +100,7 @@ class: center, middle
 
 --
 
-- All required developpement tools are already installed:
+- All required development tools are already installed:
 
   - The GNU ARM Embedded 7.3 toolchain is installed
 


### PR DESCRIPTION
This PR fixes a typo in the summit tutorial slides.